### PR TITLE
SQLite Support

### DIFF
--- a/lib/creperie/generators/templates/app/Gemfile
+++ b/lib/creperie/generators/templates/app/Gemfile
@@ -9,9 +9,11 @@ gem 'app'
 # Crêperie provides CLI convenience for your crepe app as well.
 gem 'creperie', github: 'crepe/creperie'
 
-# Use ActiveRecord to define models and PostgreSQL to store them.
+# Use ActiveRecord to define models and SQLite 3 to store them.
 gem 'activerecord', require: 'active_record'
-gem 'pg'
+gem 'sqlite3'
+# Use PostgreSQL instead.
+# gem 'pg'
 
 # Use Jsonite to convert objects to JSON for presentation. Place
 # presenters in the app/presenters/ directory.

--- a/lib/creperie/generators/templates/app/Rakefile.tt
+++ b/lib/creperie/generators/templates/app/Rakefile.tt
@@ -6,3 +6,8 @@ Dir['lib/tasks/**/*.rake'].each { |task| load task }
 
 # Load ActiveRecord Rake tasks
 load 'active_record/railties/databases.rake'
+include ActiveRecord::Tasks
+DatabaseTasks.db_dir = 'db'
+DatabaseTasks.migrations_paths = %w[db/migrate]
+DatabaseTasks.root = Crepe.root
+DatabaseTasks.env = Crepe.env

--- a/lib/creperie/generators/templates/app/config/database.yml.tt
+++ b/lib/creperie/generators/templates/app/config/database.yml.tt
@@ -1,24 +1,16 @@
 defaults: &defaults
-  adapter: postgresql
-  encoding: unicode
+  adapter: sqlite3
+  pool: 5
+  timeout: 5000
 
 development:
   <<: *defaults
-  database: <%= name %>_development
-  pool: 16
-  username: postgres
-  password:
+  database: db/development.sqlite3
 
 test:
   <<: *defaults
-  database: <%= name %>_test
-  pool: 16
-  username: postgres
-  password:
+  database: db/test.sqlite3
 
 production:
   <<: *defaults
-  database: <%= name %>_production
-  pool: 25
-  username: postgres
-  password:
+  database: db/production.sqlite3


### PR DESCRIPTION
We need to configure a few things to get everything working. As it stands, switching to SQLite 3 causes a few configuration options that default to calling `Rails.#{method}` to blow up.

See: https://github.com/rails/rails/blob/08754f12e65a9ec79633a605e986d0f1ffa4b251/activerecord/lib/active_record/tasks/database_tasks.rb#L27-L34

One thing that's missing: `DatabaseTasks.seed_loader` (an object that responds to `load_seed`). Without it, I don't think we have proper `db:seed` support (but I may be wrong).

This PR additionally changes the default from PostgreSQL to SQLite 3. I think it's the better default when you just want to hack on an idea. People'll switch to Postgres as soon as they need to, anyway.
