### PR TITLE
Implement source reloading for `crepe s` (#6)

### DIFF
--- a/creperie.gemspec
+++ b/creperie.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'clamp', '~> 0.6'
   s.add_dependency 'thor', '~> 0.19'
   s.add_dependency 'rack-console', '~> 1.3'
+  s.add_dependency 'listen', '~> 2.7'
 
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'fakefs', '~> 0.5'

--- a/lib/creperie/commands/server.rb
+++ b/lib/creperie/commands/server.rb
@@ -1,5 +1,6 @@
 require 'creperie/commands/base'
 require 'creperie/loader'
+require 'listen'
 
 module Creperie
   module Commands
@@ -38,6 +39,8 @@ module Creperie
         require 'bundler/setup'
         require 'rack'
 
+        watch_for_changes! if options[:environment] == 'development'
+
         Rack::Server.start(options)
       end
 
@@ -57,6 +60,15 @@ module Creperie
           opts[:debug]       = debug?
           opts[:warn]        = warn?
         end
+      end
+
+      def watch_for_changes!
+        listener = Listen.to Dir.pwd, only: /\.(rb|ru|yml)$/ do
+          puts 'Source code changes detected. Reloading...'
+          Kernel.exec $0, *ARGV
+        end
+
+        listener.start
       end
     end
   end

--- a/spec/commands/server_spec.rb
+++ b/spec/commands/server_spec.rb
@@ -19,7 +19,9 @@ describe Creperie::Commands::Server do
 
     it 'calls out to Rack::Server with passed/default options' do
       opts = double
-      expect(server).to       receive(:options).and_return(opts)
+      allow(opts).to receive(:[])
+
+      allow(server).to        receive(:options).and_return(opts)
       expect(Rack::Server).to receive(:start).with(opts)
 
       server.run([])


### PR DESCRIPTION
Allow `crepe s` to automatically reload source code in the development
environment when changes are detected. This will make developing Crepe
APIs much faster and users can avoid constantly restarting their rackup
servers. Fixes #6.

Signed-off-by: David Celis me@davidcel.is
